### PR TITLE
Handle dummy restart date

### DIFF
--- a/src/kubernetes.js
+++ b/src/kubernetes.js
@@ -40,6 +40,7 @@ const getDeployments = () => {
                     oldestPodsEpochs[deployment.metadata.labels.app] !== undefined) {
                     const { lastRestartDate } = deployment.spec.template.metadata.labels
                     const parsedDate = parseInt(lastRestartDate, 10)
+                    // if lastRestartDate is not a number, parsedDate is falsy
                     const version = parsedDate || oldestPodsEpochs[deployment.metadata.labels.app]
                     patchedDeployments.push({ ...deployment, version })
                   } else {

--- a/src/kubernetes.js
+++ b/src/kubernetes.js
@@ -39,9 +39,8 @@ const getDeployments = () => {
                     deployment.metadata.labels.app !== undefined &&
                     oldestPodsEpochs[deployment.metadata.labels.app] !== undefined) {
                     const { lastRestartDate } = deployment.spec.template.metadata.labels
-                    const version = lastRestartDate
-                      ? parseInt(lastRestartDate, 10)
-                      : oldestPodsEpochs[deployment.metadata.labels.app]
+                    const parsedDate = parseInt(lastRestartDate, 10)
+                    const version = parsedDate || oldestPodsEpochs[deployment.metadata.labels.app]
                     patchedDeployments.push({ ...deployment, version })
                   } else {
                     debug('Could not find pods for deployment %s', JSON.stringify(deployment))


### PR DESCRIPTION
There was an issue that deployer was not aware when the deployment was last "restarted" if the new deployment was done by applying a manifest. This pr changes so that dummy non integer values can be inserted into lastRestartDate label which override existing value when manifest is applied. Deployer then ignores lastRestartDate and checks when the pods were last restarted.