### PR TITLE
DT-6643 part2 Add deployment title for deployment image freshness monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,18 @@ Optional label that defines in minutes how long time has to be since the last re
 
 Optionally, it can be checked that an image has been updated within the last 12 hours.
 
-This can be enabled with `checkImageFreshnessAt` label that defines when the check is done in `hh.mm` format:
+Example config:
 
 ```yaml
   metadata:
     labels:
       update: "auto"
       checkImageFreshnessAt: "09.00"
+      imageFreshnessTitle: "Service_X"
 ```
+
+### checkImageFreshnessAt: "04.30"
+Label that defines when the check is done in `hh.mm`. If multiple deployments have identical check times, the checks and messaging are grouped together.
+
+### imageFreshnessTitle: "240"
+The title which is used for the deployment when messaging about image freshness over slack.

--- a/src/image-freshness-monitor.js
+++ b/src/image-freshness-monitor.js
@@ -6,8 +6,10 @@ import { postAlertSlackMessage } from './util.js'
  * has been updated within last 24 hours. If not, a message is sent to slack.
  * Configured with labels as follows:
  *  checkImageFreshnessAt: "hh.mm"
+ *  imageFreshnessTitle: "Service_X"
  * where checkImageFreshnessAt defines when the check should be done (roughly,
- * might be delayed by 0-5 mins)
+ * might be delayed by 0-5 mins) and imageFreshnessTitle is the deployment's title used in
+ * slack messaging.
  */
 export default {
   command: (deployments, context) => {
@@ -22,7 +24,7 @@ export default {
     const promises = []
     deploymentsNeedingCheck.forEach(deployment => {
       const deploymentId = deployment.metadata.labels.app
-      const deploymentTitle = deployment.metadata.labels.title || deploymentId
+      const deploymentTitle = deployment.metadata.labels.imageFreshnessTitle || deploymentId
       const image = deployment.spec.template.spec.containers[0].image
       console.log(`Deployment ${deploymentId} needs image freshness check`)
       promises.push(new Promise((resolve) => {
@@ -44,7 +46,7 @@ export default {
     Promise.all(promises).then((values) => {
       const deploymentsWithOldImages = values.filter(value => value != null)
       if (deploymentsWithOldImages.length > 0) {
-        postAlertSlackMessage(`:boom: These deployments have not been updated within the last 12 hours: ${deploymentsWithOldImages.join(', ')} :boom:`)
+        postAlertSlackMessage(`:boom: These services have not been updated within the last 12 hours: ${deploymentsWithOldImages.join(', ')} :boom:`)
       }
     })
   }

--- a/src/image-freshness-monitor.js
+++ b/src/image-freshness-monitor.js
@@ -22,14 +22,15 @@ export default {
     const promises = []
     deploymentsNeedingCheck.forEach(deployment => {
       const deploymentId = deployment.metadata.labels.app
+      const deploymentTitle = deployment.metadata.labels.title || deploymentId
       const image = deployment.spec.template.spec.containers[0].image
-      console.log(`Deployment ${deployment.metadata.labels.app} needs image freshness check`)
+      console.log(`Deployment ${deploymentId} needs image freshness check`)
       promises.push(new Promise((resolve) => {
         context.dockerRepo.getImageDate(image).then(repoImageDate => {
           // check that image is older than 12 hours old
           if (repoImageDate && repoImageDate < now.getTime() - 12 * 60 * 60 * 1000) {
             console.log('%s image has not been updated within the last 12 hours', deploymentId)
-            resolve(deployment.metadata.labels.app)
+            resolve(deploymentTitle)
           } else {
             console.log('%s image has been updated within the last 12 hours', deploymentId)
             resolve(null)

--- a/src/image-freshness-monitor.js
+++ b/src/image-freshness-monitor.js
@@ -46,7 +46,7 @@ export default {
     Promise.all(promises).then((values) => {
       const deploymentsWithOldImages = values.filter(value => value != null)
       if (deploymentsWithOldImages.length > 0) {
-        postAlertSlackMessage(`:boom: These services have not been updated within the last 12 hours: ${deploymentsWithOldImages.join(', ')} :boom:`)
+        postAlertSlackMessage(`:boom: These have not been updated within the last 12 hours: ${deploymentsWithOldImages.join(', ')} :boom:`)
       }
     })
   }


### PR DESCRIPTION
* Adds support for `imageFreshnessTitle` label to be used in image freshness monitoring slack messages so we don't have to use the technical deployment ids